### PR TITLE
Kyocera printer support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG UBUNTU_VERSION=jammy
 
 FROM ubuntu:$UBUNTU_VERSION as kyocera-builder
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install \
       libcupsimage2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install \
       libcupsimage2-dev \
       libcups2-dev \
+      libc6-dev \
       gcc \
       cmake \
       git

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,14 @@ WORKDIR /rastertokpsl-re
 RUN git checkout cbac20651fe1a40ad258397dc055254b92490054
 RUN cmake -B_build -H. && cmake --build _build/
 
-FROM ubuntu:$UBUNTU_VERSION
+FROM ubuntu:$UBUNTU_VERSION as arm64-base
+FROM ubuntu:$UBUNTU_VERSION as arm-base
+FROM ubuntu:$UBUNTU_VERSION as amd64-base
+COPY --from=kyocera-builder --chmod=0555 /rastertokpsl-re/bin/rastertokpsl-re /usr/lib/cups/filter/rastertokpsl
+RUN mkdir -p /usr/share/cups/model/Kyocera
+COPY --from=kyocera-builder /rastertokpsl-re/*.ppd /usr/share/cups/model/Kyocera/
+
+FROM ${TARGETARCH}-base
 MAINTAINER drpsychick@drsick.net
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -44,10 +51,6 @@ RUN apt-get -y install \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/* \
     && rm -rf /var/tmp/*
-
-COPY --from=kyocera-builder --chmod=0555 /rastertokpsl-re/bin/rastertokpsl-re /usr/lib/cups/filter/rastertokpsl
-RUN mkdir -p /usr/share/cups/model/Kyocera
-COPY --from=kyocera-builder /rastertokpsl-re/*.ppd /usr/share/cups/model/Kyocera/
 
 # TODO: really needed?
 #COPY mime/ /etc/cups/mime/


### PR DESCRIPTION
Not sure if this is something that should be in the main repo, but I'll still add it here.

Kyocera printers right now are a massive pain to get working, but thanks to [Fe-Ti/rastertokpsl-re](https://github.com/Fe-Ti/rastertokpsl-re) and [the PR from eLtMosen](https://github.com/eLtMosen/rastertokpsl-re/tree/add-more-printers) it's possible.

This PR clones & builds the fixed Kyocera printer drivers and then adds them to the final image. After that my FS-1041 just worked.

Docker image of this is available [here](https://hub.docker.com/repository/docker/theaninova/cups-avahi-airprint-kyocera)