### PR TITLE
Add entrypoint hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,14 @@ RUN apt-get -y install \
 
 # TODO: really needed?
 #COPY mime/ /etc/cups/mime/
-
+ARG PRE_INIT_HOOK_NAME=pre-init-script.sh
 # setup airprint scripts
 COPY airprint/ /opt/airprint/
 
 COPY healthcheck.sh /
 COPY start-cups.sh /root/
-RUN chmod +x /healthcheck.sh /root/start-cups.sh
+COPY ${PRE_INIT_HOOK_NAME} /root/
+RUN chmod +x /healthcheck.sh /root/start-cups.sh /root/${PRE_INIT_HOOK_NAME}
 HEALTHCHECK --interval=10s --timeout=3s CMD /healthcheck.sh
 
 ENV TZ="GMT" \
@@ -76,6 +77,7 @@ ENV TZ="GMT" \
     CUPS_IP="" \
     CUPS_ACCESS_LOGLEVEL="config" \
     # example: lpadmin -p Epson-RX520 -D 'my RX520' -m 'gutenprint.5.3://escp2-rx620/expert' -v smb://user:pass@host/Epson-RX520"
-    CUPS_LPADMIN_PRINTER1=""
+    CUPS_LPADMIN_PRINTER1="" \
+    PRE_INIT_HOOK="/root/${PRE_INIT_HOOK_NAME}"
 
 ENTRYPOINT ["/root/start-cups.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,14 @@ RUN apt-get -y install \
 
 # TODO: really needed?
 #COPY mime/ /etc/cups/mime/
-ARG PRE_INIT_HOOK_NAME=pre-init-script.sh
+
 # setup airprint scripts
 COPY airprint/ /opt/airprint/
 
 COPY healthcheck.sh /
 COPY start-cups.sh /root/
-COPY ${PRE_INIT_HOOK_NAME} /root/
-RUN chmod +x /healthcheck.sh /root/start-cups.sh /root/${PRE_INIT_HOOK_NAME}
+COPY pre-init-script.sh /root/
+RUN chmod +x /healthcheck.sh /root/start-cups.sh /root/pre-init-script.sh
 HEALTHCHECK --interval=10s --timeout=3s CMD /healthcheck.sh
 
 ENV TZ="GMT" \
@@ -77,7 +77,6 @@ ENV TZ="GMT" \
     CUPS_IP="" \
     CUPS_ACCESS_LOGLEVEL="config" \
     # example: lpadmin -p Epson-RX520 -D 'my RX520' -m 'gutenprint.5.3://escp2-rx620/expert' -v smb://user:pass@host/Epson-RX520"
-    CUPS_LPADMIN_PRINTER1="" \
-    PRE_INIT_HOOK="/root/${PRE_INIT_HOOK_NAME}"
+    CUPS_LPADMIN_PRINTER1=""
 
 ENTRYPOINT ["/root/start-cups.sh"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ AVAHI_INTERFACES=${AVAHI_INTERFACES:=""}
 AVAHI_IPV6=${AVAHI_IPV6:="no"}
 AVAHI_REFLECTOR=${AVAHI_REFLECTOR:="no"}
 AVAHI_REFLECT_IPV=${AVAHI_REFLECT_IPV:="no"}
+PRE_INIT_HOOK=${PRE_INIT_HOOK:="/root/pre-init-script.sh"} # This hook offers you the possibility to execute a custom script before the printer gets installed and before CUPS starts. You can either specify a path to a script or a command.
+
 ```
 
 ### Add printer through ENV

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ AVAHI_INTERFACES=${AVAHI_INTERFACES:=""}
 AVAHI_IPV6=${AVAHI_IPV6:="no"}
 AVAHI_REFLECTOR=${AVAHI_REFLECTOR:="no"}
 AVAHI_REFLECT_IPV=${AVAHI_REFLECT_IPV:="no"}
-PRE_INIT_HOOK=${PRE_INIT_HOOK:="/root/pre-init-script.sh"} # This hook offers you the possibility to execute a custom script before the printer gets installed and before CUPS starts. You can either specify a path to a script or a command.
+PRE_INIT_HOOK=${PRE_INIT_HOOK:="/root/pre-init-script.sh"} # A path to a script OR a command. This offers the possibility to execute a custom script before the printer gets installed and before CUPS starts.
 
 ```
 

--- a/pre-init-script.sh
+++ b/pre-init-script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+PRE_INIT_HOOK=${PRE_INIT_HOOK:="/root/pre-init-script.sh"}
+
+echo "This is an example/dummy pre-init script. It does nothing by default.
+If you want to execute your own code & logic (e.g., installing a printer driver via a shell script or apt)
+before everything initializes and starts up 
+then:
+    a) Replace this file via a volume mount (-v /path/to/host/script:${PRE_INIT_HOOK})
+or  
+    b) Change the environment variable 'PRE_INIT_HOOK' to your custom path or command 
+       that should be executed inside the container."

--- a/pre-init-script.sh
+++ b/pre-init-script.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-PRE_INIT_HOOK=${PRE_INIT_HOOK:="/root/pre-init-script.sh"}
 
 echo "This is an example/dummy pre-init script. It does nothing by default.
 If you want to execute your own code & logic (e.g., installing a printer driver via a shell script or apt)
 before everything initializes and starts up 
 then:
-    a) Replace this file via a volume mount (-v /path/to/host/script:${PRE_INIT_HOOK})
+    a) Replace this file via a volume mount (-v /path/to/host/script:/root/pre-init-script.sh)
 or  
-    b) Change the environment variable 'PRE_INIT_HOOK' to your custom path or command 
+    b) Change the environment variable 'PRE_INIT_HOOK' to your custom (mounted) path or command 
        that should be executed inside the container."

--- a/start-cups.sh
+++ b/start-cups.sh
@@ -74,15 +74,13 @@ sed -i "s/^.*reflect\-ipv=.*/reflect\-ipv\=${AVAHI_REFLECT_IPV}/" /etc/avahi/ava
 sed -i 's/^.*enable-dbus=.*/enable-dbus=no/' /etc/avahi/avahi-daemon.conf
 
 # Run custom user code before starting any service
-if [ -n "$PRE_INIT_HOOK" ]; then
-  # Check if PRE_INIT_HOOK is a file path
-  if [ -f "$PRE_INIT_HOOK" ]; then
-      echo "Executing script at $PRE_INIT_HOOK"
-      /bin/bash "$PRE_INIT_HOOK"
-  else # or a command
-      echo "Executing command: $PRE_INIT_HOOK"
-      /bin/bash -c "$PRE_INIT_HOOK"
-  fi
+# Check if PRE_INIT_HOOK is a file path
+if [ -f "$PRE_INIT_HOOK" ]; then
+    echo "Executing script at $PRE_INIT_HOOK"
+    /bin/bash "$PRE_INIT_HOOK"
+else # or a command
+    echo "Executing command: $PRE_INIT_HOOK"
+    /bin/bash -c "$PRE_INIT_HOOK"
 fi
 
 # start automatic printer refresh for avahi

--- a/start-cups.sh
+++ b/start-cups.sh
@@ -74,13 +74,15 @@ sed -i "s/^.*reflect\-ipv=.*/reflect\-ipv\=${AVAHI_REFLECT_IPV}/" /etc/avahi/ava
 sed -i 's/^.*enable-dbus=.*/enable-dbus=no/' /etc/avahi/avahi-daemon.conf
 
 # Run custom user code before starting any service
-# Check if PRE_INIT_HOOK is a file path
-if [ -f "$PRE_INIT_HOOK" ]; then
-    echo "Executing script at $PRE_INIT_HOOK"
-    /bin/bash "$PRE_INIT_HOOK"
-else
-    echo "Executing command: $PRE_INIT_HOOK"
-    /bin/bash -c "$PRE_INIT_HOOK"
+if [ -n "$PRE_INIT_HOOK" ]; then
+  # Check if PRE_INIT_HOOK is a file path
+  if [ -f "$PRE_INIT_HOOK" ]; then
+      echo "Executing script at $PRE_INIT_HOOK"
+      /bin/bash "$PRE_INIT_HOOK"
+  else # or a command
+      echo "Executing command: $PRE_INIT_HOOK"
+      /bin/bash -c "$PRE_INIT_HOOK"
+  fi
 fi
 
 # start automatic printer refresh for avahi

--- a/start-cups.sh
+++ b/start-cups.sh
@@ -21,6 +21,7 @@ AVAHI_FRIENDLY_DESC=${AVAHI_FRIENDLY_DESC=:-"no"}
 AVAHI_IPV6=${AVAHI_IPV6:="no"}
 AVAHI_REFLECTOR=${AVAHI_REFLECTOR:="no"}
 AVAHI_REFLECT_IPV=${AVAHI_REFLECT_IPV:="no"}
+PRE_INIT_HOOK=${PRE_INIT_HOOK:="/root/pre-init-script.sh"} 
 [ "yes" = "${CUPS_ENV_DEBUG}" ] && export -n
 
 ### check for valid input
@@ -71,6 +72,16 @@ sed -i "s/^.*publish-aaaa-on-ipv4=.*/publish-aaaa-on-ipv4=${AVAHI_IPV6}/" /etc/a
 sed -i "s/^.*enable\-reflector=.*/enable\-reflector\=${AVAHI_REFLECTOR}/" /etc/avahi/avahi-daemon.conf
 sed -i "s/^.*reflect\-ipv=.*/reflect\-ipv\=${AVAHI_REFLECT_IPV}/" /etc/avahi/avahi-daemon.conf
 sed -i 's/^.*enable-dbus=.*/enable-dbus=no/' /etc/avahi/avahi-daemon.conf
+
+# Run custom user code before starting any service
+# Check if PRE_INIT_HOOK is a file path
+if [ -f "$PRE_INIT_HOOK" ]; then
+    echo "Executing script at $PRE_INIT_HOOK"
+    /bin/bash "$PRE_INIT_HOOK"
+else
+    echo "Executing command: $PRE_INIT_HOOK"
+    /bin/bash -c "$PRE_INIT_HOOK"
+fi
 
 # start automatic printer refresh for avahi
 /opt/airprint/printer-update.sh &


### PR DESCRIPTION
See discussion here:
[Add possibility to install additional drivers (or to run custom init scripts)](https://github.com/SickHub/docker-cups-airprint/issues/81#top)

There it also the option to just let the environment variable empty by default, but I thought I'd add an example script as a starting point for users. It is up to you if you take the dummy script or not :)

BR
teoli